### PR TITLE
Format 999 references with subscripts

### DIFF
--- a/SearchLedger/index.html
+++ b/SearchLedger/index.html
@@ -2516,6 +2516,10 @@ now
         }
 
 
+        function applySubindices(str) {
+            return str.replace(/999(?:_|\.)?(\d+)/g, '999<sub>$1</sub>');
+        }
+
         function displayEntries(entriesToDisplay, searchTerm = "") {
             const container = document.getElementById('ledgerEntries');
             container.innerHTML = '';
@@ -2545,6 +2549,10 @@ now
                         descriptionHTML = entry.description.replace(searchRegex, match => `<span class="highlight">${match}</span>`);
                     }
                 }
+
+                idHTML = applySubindices(idHTML);
+                titleHTML = applySubindices(titleHTML);
+                descriptionHTML = applySubindices(descriptionHTML);
                 
                 const idEl = document.createElement('span');
                 idEl.className = 'entry-id';


### PR DESCRIPTION
## Summary
- add helper to format `999_##` and `999##` references as `999<sub>##</sub>`
- update `displayEntries` to apply new formatting on ids, titles and descriptions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841d7c73be08322b2b1abe8338c7f60