### PR TITLE
Add negative entries after main ledger

### DIFF
--- a/SearchLedger/ledger.js
+++ b/SearchLedger/ledger.js
@@ -5320,5 +5320,920 @@ const ledgerEntries =
     "id": "1000",
     "title": "Boxed",
     "description": "End of part I."
-  }
+  },
+  {
+    "id": "-1",
+    "title": "",
+    "description": ""
+  },
+  {
+    "id": "-2",
+    "title": "Grapes of the Wildy",
+    "description": ""
+  },
+  {
+    "id": "-3",
+    "title": "Jake of Water",
+    "description": ""
+  },
+  {
+    "id": "-4",
+    "title": "Frankie of Freaks",
+    "description": ""
+  },
+  {
+    "id": "-5",
+    "title": "Chet of the Fallen",
+    "description": ""
+  },
+  {
+    "id": "-6",
+    "title": "Angel of Love and All Causes",
+    "description": ""
+  },
+  {
+    "id": "-7",
+    "title": "Julian the Knight",
+    "description": ""
+  },
+  {
+    "id": "-8",
+    "title": "Sustain Shoe",
+    "description": ""
+  },
+  {
+    "id": "-9",
+    "title": "Benjamin of the Diet Haterade",
+    "description": ""
+  },
+  {
+    "id": "-10",
+    "title": "Soso of Gluten Freedom",
+    "description": ""
+  },
+  {
+    "id": "-11",
+    "title": "Brian of Music",
+    "description": ""
+  },
+  {
+    "id": "-12",
+    "title": "Ali of the Mushroom Village",
+    "description": ""
+  },
+  {
+    "id": "-13",
+    "title": "Danji of Autonomy",
+    "description": ""
+  },
+  {
+    "id": "-14",
+    "title": "Marco the Lucky",
+    "description": ""
+  },
+  {
+    "id": "-15",
+    "title": "Evan of Sincerity",
+    "description": ""
+  },
+  {
+    "id": "-16",
+    "title": "Charlie the Gnarly",
+    "description": ""
+  },
+  {
+    "id": "-17",
+    "title": "Jack of Music",
+    "description": ""
+  },
+  {
+    "id": "-18",
+    "title": "Erika of Good Times",
+    "description": ""
+  },
+  {
+    "id": "-19",
+    "title": "Ray of Tunes",
+    "description": ""
+  },
+  {
+    "id": "-20",
+    "title": "Wes of Quality",
+    "description": ""
+  },
+  {
+    "id": "-21",
+    "title": "Justin of the Rail",
+    "description": ""
+  },
+  {
+    "id": "-22",
+    "title": "Din of Compassion",
+    "description": ""
+  },
+  {
+    "id": "-23",
+    "title": "Kavan of the Move",
+    "description": ""
+  },
+  {
+    "id": "-24",
+    "title": "Aurora of Sustain-Release",
+    "description": ""
+  },
+  {
+    "id": "-25",
+    "title": "Greg of Honesty",
+    "description": ""
+  },
+  {
+    "id": "-26",
+    "title": "Liv of Ubiquity",
+    "description": ""
+  },
+  {
+    "id": "-27",
+    "title": "Dre the Electric-God-Win-Fist",
+    "description": ""
+  },
+  {
+    "id": "-28",
+    "title": "Shaquille the humble",
+    "description": ""
+  },
+  {
+    "id": "-29",
+    "title": "Dutch of Authenticity",
+    "description": ""
+  },
+  {
+    "id": "-30",
+    "title": "Duggan of the lawful love",
+    "description": ""
+  },
+  {
+    "id": "-31",
+    "title": "John of EMS 21",
+    "description": ""
+  },
+  {
+    "id": "-32",
+    "title": "Eris of the Mother Beat",
+    "description": ""
+  },
+  {
+    "id": "-33",
+    "title": "Eve of Shadow Step",
+    "description": ""
+  },
+  {
+    "id": "-34",
+    "title": "Sergio the Botantist",
+    "description": ""
+  },
+  {
+    "id": "-35",
+    "title": "Aaron of You",
+    "description": ""
+  },
+  {
+    "id": "-36",
+    "title": "Michael of Second Chances",
+    "description": ""
+  },
+  {
+    "id": "-37",
+    "title": "Eugene of Having Fun",
+    "description": ""
+  },
+  {
+    "id": "-38",
+    "title": "Basement Reject",
+    "description": ""
+  },
+  {
+    "id": "-39",
+    "title": "",
+    "description": ""
+  },
+  {
+    "id": "-40",
+    "title": "Bob of of Life and Fulfilling our Potential",
+    "description": ""
+  },
+  {
+    "id": "-41",
+    "title": "Jeff of Conductivity",
+    "description": ""
+  },
+  {
+    "id": "-42",
+    "title": "Ian the Fierce",
+    "description": ""
+  },
+  {
+    "id": "-43",
+    "title": "Vinh of Gender Self-Determination",
+    "description": ""
+  },
+  {
+    "id": "-44",
+    "title": "Clay of Soot",
+    "description": ""
+  },
+  {
+    "id": "-45",
+    "title": "James of Family/Friends",
+    "description": ""
+  },
+  {
+    "id": "-46",
+    "title": "Carly of Happiness",
+    "description": ""
+  },
+  {
+    "id": "-47",
+    "title": "Claudia of the Lake",
+    "description": ""
+  },
+  {
+    "id": "-48",
+    "title": "Irene the Kind Hand of Power",
+    "description": ""
+  },
+  {
+    "id": "-49",
+    "title": "Jansen of Perseverance",
+    "description": ""
+  },
+  {
+    "id": "-50",
+    "title": "Cutty of the Corner",
+    "description": ""
+  },
+  {
+    "id": "-51",
+    "title": "Jenna of Healthy Snack Foods",
+    "description": ""
+  },
+  {
+    "id": "-52",
+    "title": "Miles of the American Dream",
+    "description": ""
+  },
+  {
+    "id": "-53",
+    "title": "Reign of Terror",
+    "description": ""
+  },
+  {
+    "id": "-54",
+    "title": "Omar of the Dance Floor",
+    "description": ""
+  },
+  {
+    "id": "-55",
+    "title": "Ron of Love and Sand",
+    "description": ""
+  },
+  {
+    "id": "-56",
+    "title": "Eddy of the People",
+    "description": ""
+  },
+  {
+    "id": "-57",
+    "title": "Job of Atmospheres",
+    "description": ""
+  },
+  {
+    "id": "-58",
+    "title": "Yates of Earnesty",
+    "description": ""
+  },
+  {
+    "id": "-59",
+    "title": "Ariana of Techno",
+    "description": ""
+  },
+  {
+    "id": "-60",
+    "title": "Na, the one and only",
+    "description": ""
+  },
+  {
+    "id": "-61",
+    "title": "Scott of Attunement",
+    "description": ""
+  },
+  {
+    "id": "-62",
+    "title": "Perri the Blue",
+    "description": ""
+  },
+  {
+    "id": "-63",
+    "title": "Mar of Terminal Curiousity",
+    "description": ""
+  },
+  {
+    "id": "-64",
+    "title": "Basement (solved by Jan)",
+    "description": ""
+  },
+  {
+    "id": "-65",
+    "title": "Paolo & Leno",
+    "description": ""
+  },
+  {
+    "id": "-66",
+    "title": "[regifted] Terra",
+    "description": ""
+  },
+  {
+    "id": "-67",
+    "title": "Crihs of New York",
+    "description": ""
+  },
+  {
+    "id": "-68",
+    "title": "Klara of Dark Wit",
+    "description": ""
+  },
+  {
+    "id": "-69",
+    "title": "Tyrone of Batangas",
+    "description": ""
+  },
+  {
+    "id": "-70",
+    "title": "Amanda of Creative Expression",
+    "description": ""
+  },
+  {
+    "id": "-71",
+    "title": "Jarrod of Faggotry",
+    "description": ""
+  },
+  {
+    "id": "-72",
+    "title": "Aya of Arthrosis",
+    "description": ""
+  },
+  {
+    "id": "-73",
+    "title": "Anais of Chosen Family",
+    "description": ""
+  },
+  {
+    "id": "-74",
+    "title": "Ramses of Ichi",
+    "description": ""
+  },
+  {
+    "id": "-75",
+    "title": "Sophia of Development",
+    "description": ""
+  },
+  {
+    "id": "-76",
+    "title": "Christian the Peace Maker",
+    "description": ""
+  },
+  {
+    "id": "-77",
+    "title": "Ashley the Social Activist",
+    "description": ""
+  },
+  {
+    "id": "-78",
+    "title": "Amanda of Poetic Justice",
+    "description": ""
+  },
+  {
+    "id": "-79",
+    "title": "Hamza of Peace",
+    "description": ""
+  },
+  {
+    "id": "-80",
+    "title": "Ne/Re/A",
+    "description": ""
+  },
+  {
+    "id": "-81",
+    "title": "Sharif of Freedom",
+    "description": ""
+  },
+  {
+    "id": "-82",
+    "title": "Richard the Sight",
+    "description": ""
+  },
+  {
+    "id": "-83",
+    "title": "Dean of Silt",
+    "description": ""
+  },
+  {
+    "id": "-84",
+    "title": "TK",
+    "description": ""
+  },
+  {
+    "id": "-85",
+    "title": "Ramiel, Angel of Thunder",
+    "description": ""
+  },
+  {
+    "id": "-86",
+    "title": "Reggie of Kansas City",
+    "description": ""
+  },
+  {
+    "id": "-87",
+    "title": "India the Composer",
+    "description": ""
+  },
+  {
+    "id": "-88",
+    "title": "Keilah of Enlightenment",
+    "description": ""
+  },
+  {
+    "id": "-89",
+    "title": "Keira of Non-Fiction Story-Telling",
+    "description": ""
+  },
+  {
+    "id": "-90",
+    "title": "Valentyn of Cookies",
+    "description": ""
+  },
+  {
+    "id": "-91",
+    "title": "Dana of BOND",
+    "description": ""
+  },
+  {
+    "id": "-92",
+    "title": "Raul the Eye of the Afters",
+    "description": ""
+  },
+  {
+    "id": "-93",
+    "title": "Sam of Mot**ē**",
+    "description": ""
+  },
+  {
+    "id": "-94",
+    "title": "Shalma of Curious Minds",
+    "description": ""
+  },
+  {
+    "id": "-95",
+    "title": "Nicole of Independent Bitches",
+    "description": ""
+  },
+  {
+    "id": "-96",
+    "title": "Patrick the Peaceful",
+    "description": ""
+  },
+  {
+    "id": "-97",
+    "title": "Andrew the Moralistic Communist",
+    "description": ""
+  },
+  {
+    "id": "-98",
+    "title": "JoJo of Good Chaos",
+    "description": ""
+  },
+  {
+    "id": "-99",
+    "title": "Kitty of the Dive Bars",
+    "description": ""
+  },
+  {
+    "id": "-100",
+    "title": "Spring Point Lighthouse",
+    "description": ""
+  },
+  {
+    "id": "-101",
+    "title": "Chris, the Crust of Portland",
+    "description": ""
+  },
+  {
+    "id": "-102",
+    "title": "Mitchell the penawahpskewi Artist",
+    "description": ""
+  },
+  {
+    "id": "-103",
+    "title": "Sophia of Gay Sex",
+    "description": ""
+  },
+  {
+    "id": "-104",
+    "title": "Mo the Pending",
+    "description": ""
+  },
+  {
+    "id": "-105",
+    "title": "Clarisa of Personal Choice",
+    "description": ""
+  },
+  {
+    "id": "-106",
+    "title": "Law of Noise",
+    "description": ""
+  },
+  {
+    "id": "-107",
+    "title": "Elinah “Bobby Blis?”",
+    "description": ""
+  },
+  {
+    "id": "-108",
+    "title": "Ryan of the Swamp",
+    "description": ""
+  },
+  {
+    "id": "-109",
+    "title": "Destiny of Fitness",
+    "description": ""
+  },
+  {
+    "id": "-110",
+    "title": "Max of Unity",
+    "description": ""
+  },
+  {
+    "id": "-111",
+    "title": "Rachel of the B. of the D.",
+    "description": ""
+  },
+  {
+    "id": "-112",
+    "title": "Ross of Strength",
+    "description": ""
+  },
+  {
+    "id": "-113",
+    "title": "Sean the Wanderer",
+    "description": ""
+  },
+  {
+    "id": "-114",
+    "title": "Nowadays (hidden)",
+    "description": ""
+  },
+  {
+    "id": "-115",
+    "title": "Tom of the Clean Environment",
+    "description": ""
+  },
+  {
+    "id": "-116",
+    "title": "Rinker of the Rat",
+    "description": ""
+  },
+  {
+    "id": "-117",
+    "title": "Alex",
+    "description": ""
+  },
+  {
+    "id": "-118",
+    "title": "Rrose",
+    "description": ""
+  },
+  {
+    "id": "-119",
+    "title": "Taco Maniac",
+    "description": ""
+  },
+  {
+    "id": "-120",
+    "title": "Bella, beneficiary of Alex",
+    "description": ""
+  },
+  {
+    "id": "-121",
+    "title": "Michael the Gracious",
+    "description": ""
+  },
+  {
+    "id": "-122",
+    "title": "Dorian of Positivity",
+    "description": ""
+  },
+  {
+    "id": "-123",
+    "title": "Lou the W.I.P.",
+    "description": ""
+  },
+  {
+    "id": "-124",
+    "title": "Marie the Sun Queen",
+    "description": ""
+  },
+  {
+    "id": "-125",
+    "title": "Maxwell the Villain",
+    "description": ""
+  },
+  {
+    "id": "-126",
+    "title": "Chuckie of Riverdale",
+    "description": ""
+  },
+  {
+    "id": "-127",
+    "title": "Diablo",
+    "description": ""
+  },
+  {
+    "id": "-128",
+    "title": "Vudu & Voodoo",
+    "description": ""
+  },
+  {
+    "id": "-129",
+    "title": "Jon-Ray from Laguna",
+    "description": ""
+  },
+  {
+    "id": "-130",
+    "title": "Kat the Self-Actualized",
+    "description": ""
+  },
+  {
+    "id": "-131",
+    "title": "Sami the Builder",
+    "description": ""
+  },
+  {
+    "id": "-132",
+    "title": "Brook the Fun",
+    "description": ""
+  },
+  {
+    "id": "-133",
+    "title": "Kyra of Good Vibes",
+    "description": ""
+  },
+  {
+    "id": "-134",
+    "title": "Array of Multitudes",
+    "description": ""
+  },
+  {
+    "id": "-135",
+    "title": "Naje of Renaissance",
+    "description": ""
+  },
+  {
+    "id": "-136",
+    "title": "Greg of the Artist",
+    "description": ""
+  },
+  {
+    "id": "-137",
+    "title": "Ash of Lord Anna",
+    "description": ""
+  },
+  {
+    "id": "-138",
+    "title": "A³",
+    "description": ""
+  },
+  {
+    "id": "-139",
+    "title": "Mo Peace",
+    "description": ""
+  },
+  {
+    "id": "-140",
+    "title": "Amelia the Mystery",
+    "description": ""
+  },
+  {
+    "id": "-141",
+    "title": "Max the Dance Floor Diva",
+    "description": ""
+  },
+  {
+    "id": "-142",
+    "title": "Alex the Kind",
+    "description": ""
+  },
+  {
+    "id": "-143",
+    "title": "Someone Devoye Loves",
+    "description": ""
+  },
+  {
+    "id": "-144",
+    "title": "Gerald of Legs",
+    "description": ""
+  },
+  {
+    "id": "-145",
+    "title": "Dante of the Flowers",
+    "description": ""
+  },
+  {
+    "id": "-146",
+    "title": "Javier the Supreme",
+    "description": ""
+  },
+  {
+    "id": "-147",
+    "title": "Jesse of Here",
+    "description": ""
+  },
+  {
+    "id": "-148",
+    "title": "Tom the Anti-Fascist",
+    "description": ""
+  },
+  {
+    "id": "-149",
+    "title": "&rea the Detached",
+    "description": ""
+  },
+  {
+    "id": "-150",
+    "title": "VRIL",
+    "description": ""
+  },
+  {
+    "id": "-151",
+    "title": "Marina of Light",
+    "description": ""
+  },
+  {
+    "id": "-152",
+    "title": "Petal of the Swamp Cedar",
+    "description": ""
+  },
+  {
+    "id": "-153",
+    "title": "Jim of Bristol (OM Unit)",
+    "description": ""
+  },
+  {
+    "id": "-154",
+    "title": "Neal of Self-Love (MoMA)",
+    "description": ""
+  },
+  {
+    "id": "-155",
+    "title": "Alex the PLO-Man",
+    "description": ""
+  },
+  {
+    "id": "-156",
+    "title": "Fernando, a guy [pissing on my car]",
+    "description": ""
+  },
+  {
+    "id": "-157",
+    "title": "Miles, not Davis, but taste",
+    "description": ""
+  },
+  {
+    "id": "-158",
+    "title": "SIGNAL",
+    "description": ""
+  },
+  {
+    "id": "-159",
+    "title": "Shane of Music + Love",
+    "description": ""
+  },
+  {
+    "id": "-160",
+    "title": "Nick of Salmon Records",
+    "description": ""
+  },
+  {
+    "id": "-161",
+    "title": "Ron Trent",
+    "description": ""
+  },
+  {
+    "id": "-162",
+    "title": "GeoDancer",
+    "description": ""
+  },
+  {
+    "id": "-163",
+    "title": "Jennifer of Sand",
+    "description": ""
+  },
+  {
+    "id": "-164",
+    "title": "Husky the Bouncer",
+    "description": ""
+  },
+  {
+    "id": "-165",
+    "title": "Will Jack of Toss'd",
+    "description": ""
+  },
+  {
+    "id": "-166",
+    "title": "Yaz of Bushwick, Born + Raised",
+    "description": ""
+  },
+  {
+    "id": "-167",
+    "title": "Alex of New Years",
+    "description": ""
+  },
+  {
+    "id": "-168",
+    "title": "Eveline, the House of Birds",
+    "description": ""
+  },
+  {
+    "id": "-169",
+    "title": "Jacob of Cysteine",
+    "description": ""
+  },
+  {
+    "id": "-170",
+    "title": "Chiara the Singer",
+    "description": ""
+  },
+  {
+    "id": "-171",
+    "title": "Emmaline the Dawn",
+    "description": ""
+  },
+  {
+    "id": "-172",
+    "title": "Arielle of HEADS–KNOW",
+    "description": ""
+  },
+  {
+    "id": "-173",
+    "title": "Karan the Great",
+    "description": ""
+  },
+  {
+    "id": "-174",
+    "title": "Pegggatron",
+    "description": ""
+  },
+  {
+    "id": "-175",
+    "title": "Nedda of the Unworldly Things",
+    "description": ""
+  },
+  {
+    "id": "-176",
+    "title": "Drew the Vagabond",
+    "description": ""
+  },
+  {
+    "id": "-177",
+    "title": "Matt of the Soil",
+    "description": ""
+  },
+  {
+    "id": "-178",
+    "title": "Jasmine of Friends",
+    "description": ""
+  },
+  {
+    "id": "-179",
+    "title": "Rin the Trickster",
+    "description": ""
+  },
+  {
+    "id": "-180",
+    "title": "Chris the Dingus",
+    "description": ""
+  },
+  {
+    "id": "-181",
+    "title": "Meredith the Dandy",
+    "description": ""
+  },
+  {
+    "id": "-182",
+    "title": "Tomás Worldbuilder",
+    "description": ""
+  },
+  {
+    "id": "-183",
+    "title": "Gorinto",
+    "description": ""
+  },
 ];


### PR DESCRIPTION
## Summary
- reordered the 183 negative id entries to come after id `1000` in `SearchLedger/ledger.js`

## Testing
- `node -e "require('./SearchLedger/ledger.js');"`


------
https://chatgpt.com/codex/tasks/task_e_68446f28a52483229461c8b73e402f34