### PR TITLE
Add black shimmer effect to Nyetscape links

### DIFF
--- a/Nyetscape.html
+++ b/Nyetscape.html
@@ -72,11 +72,26 @@
       font-size: 1rem;
       line-height: 1;
     }
+
+    /* Black shimmer effect from marginary page */
+    .black-shimmer {
+      color: #000;
+      text-decoration: none;
+      animation: black-shimmer 2s ease-in-out infinite;
+    }
+    @keyframes black-shimmer {
+      0%, 100% {
+        text-shadow: 0 0 0 rgba(0, 0, 0, 0.1);
+      }
+      50% {
+        text-shadow: 0 0 6px rgba(0, 0, 0, 0.4);
+      }
+    }
   </style>
 </head>
 <body>
   <div class="toc">
-    <div class="title"><a href="https://imaginary.solutions/documents/Bounds.pdf">Uncertainties in Nyetology</a></div>
+    <div class="title"><a href="https://imaginary.solutions/documents/Bounds.pdf" class="black-shimmer">Uncertainties in Nyetology</a></div>
 
     <h2>Preamble</h2>
 


### PR DESCRIPTION
## Summary
- add CSS for black shimmer effect, mirroring the marginary page
- apply the effect to the Nyetscape document link

## Testing
- `npx --yes htmlhint Nyetscape.html`

------
https://chatgpt.com/codex/tasks/task_e_68508d4976148322a09258cfefce4088