### PR TITLE
Fix Nyetscape link shimmer

### DIFF
--- a/Nyetscape.html
+++ b/Nyetscape.html
@@ -73,18 +73,18 @@
       line-height: 1;
     }
 
-    /* Black shimmer effect from marginary page */
+    /* Subtle white shimmer instead of black */
     .black-shimmer {
-      color: #000;
+      color: #fff;
       text-decoration: none;
       animation: black-shimmer 2s ease-in-out infinite;
     }
     @keyframes black-shimmer {
       0%, 100% {
-        text-shadow: 0 0 0 rgba(0, 0, 0, 0.1);
+        text-shadow: 0 0 0 rgba(255, 255, 255, 0.1);
       }
       50% {
-        text-shadow: 0 0 6px rgba(0, 0, 0, 0.4);
+        text-shadow: 0 0 6px rgba(255, 255, 255, 0.4);
       }
     }
   </style>


### PR DESCRIPTION
## Summary
- adjust `.black-shimmer` to use a faint white glow rather than black

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850902d96f88322ab9e6e7fa1c39c84