### PR TITLE
Fix dropdown spacing on marginary page

### DIFF
--- a/marginary.html
+++ b/marginary.html
@@ -171,14 +171,14 @@
                           <p class="rl_navbar5_text-small">Don&#x27;t start a book with its cover they said.</p>
                         </div>
                       </a>
+                      <a href="sealed.html" class="rl_navbar5_dropdown-link w-inline-block">
+                        <div class="rl_navbar5_icon-wrapper"><img src="images/Spiral256.png" loading="lazy" alt="" class="rl_navbar5_icon"></div>
+                        <div class="rl_navbar5_item-right">
+                          <div class="rl_navbar5_item-titlee-sealed">Unit Zero</div>
+                          <p class="rl_navbar5_text-small">That&#x27;s the point!</p>
+                        </div>
+                      </a>
                     </div>
-                    <a href="sealed.html" class="rl_navbar5_dropdown-link w-inline-block">
-                      <div class="rl_navbar5_icon-wrapper"><img src="images/Spiral256.png" loading="lazy" alt="" class="rl_navbar5_icon"></div>
-                      <div class="rl_navbar5_item-right">
-                        <div class="rl_navbar5_item-titlee-sealed">Unit Zero</div>
-                        <p class="rl_navbar5_text-small">That&#x27;s the point!</p>
-                      </div>
-                    </a>
                   </div>
                 </div>
                 <div class="rl_navbar5_container"></div>


### PR DESCRIPTION
## Summary
- keep `Unit Zero` inside the dropdown list so it lines up with other items

## Testing
- `git diff marginary.html`

------
https://chatgpt.com/codex/tasks/task_e_6850916542a48322824263281fb143d3