### PR TITLE
Fix contact link and background style

### DIFF
--- a/marginary.html
+++ b/marginary.html
@@ -41,7 +41,7 @@
     }
   </style>
 </head>
-<body class="body-2">
+<body class="body-2" style="background-attachment: fixed;">
   <section data-w-id="cc6747b0-5c46-8cd4-59d5-693d5595ef5a" style="opacity:0" class="hero-stack">
     <div fs-scrolldisable-element="smart-nav" data-animation="default" data-collapse="medium" data-duration="400" data-easing="ease" data-easing2="ease" role="banner" class="rl_navbar5_component w-nav">
       <div class="rl_navbar5_container">
@@ -194,7 +194,7 @@
     </div>
     <div data-w-id="cc6747b0-5c46-8cd4-59d5-693d5595ef5b" style="opacity:0" class="container-3">
       <div class="hero-wrapper-two">
-        <p class="paragraph-2">Any attempt to challenge the proverbial &quot;norm&quot; requires a foray into the imaginary. Amongst the tall grasses of the impossible, there lurk wild solutions and nascent problems.<br><br>Seek <a href="SearchLedger/index.html" class="rl_navbar5_item-titlee-sealed black-shimmer">The Ledger</a>, if you are plighted.<br>Enter <a href="Nyetscape.html" class="rl_navbar5_item-titlee-sealed black-shimmer">Nyetology</a>, if you believe &quot;no&quot; might birth a new beginning.<br><br>We direct you to explore.<br><br>If you are seeking cement, feel free to contact us at<br>cement@imaginary.solutions</p>
+        <p class="paragraph-2">Any attempt to challenge the proverbial &quot;norm&quot; requires a foray into the imaginary. Amongst the tall grasses of the impossible, there lurk wild solutions and nascent problems.<br><br>Seek <a href="SearchLedger/index.html" class="rl_navbar5_item-titlee-sealed black-shimmer">The Ledger</a>, if you are plighted.<br>Enter <a href="Nyetscape.html" class="rl_navbar5_item-titlee-sealed black-shimmer">Nyetology</a>, if you believe &quot;no&quot; might birth a new beginning.<br><br>We direct you to explore.<br><br>If you are seeking cement, feel free to contact us at<br><a href="mailto:cement@imaginary.solutions" class="black-shimmer">cement@imaginary.solutions</a></p>
       </div>
       <div class="div-block"></div>
     </div>


### PR DESCRIPTION
## Summary
- convert the cement contact text into a mailto link
- ensure the marginary page background stays fixed

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68509a9cbac0832295bd36905d9a8600