### PR TITLE
Fix marginary page layout and background

### DIFF
--- a/css/imaginary-solutions.webflow.css
+++ b/css/imaginary-solutions.webflow.css
@@ -384,7 +384,7 @@
 }
 
 .hero-wrapper-two {
-  max-width: 750px;
+  max-width: 100%;
   text-align: center;
   border: 1px #000;
   flex-direction: column;

--- a/marginary.html
+++ b/marginary.html
@@ -21,12 +21,16 @@
   <link href="images/webclip.png" rel="apple-touch-icon">
   <style>
     /* Style hyperlinks on this page */
-    body.body-2 {
-      background-attachment: fixed;
-    }
-    body.body-2 a {
-      font-size: 1.2em;
-      font-weight: 700;
+      body.body-2 {
+        background-image: url('images/Spiral2.png');
+        background-size: cover;
+        background-position: center;
+        background-repeat: no-repeat;
+        background-attachment: fixed;
+      }
+      body.body-2 a {
+        font-size: 1.2em;
+        font-weight: 700;
     }
     body.body-2 a:hover {
       animation: shimmer 0.7s ease-in-out infinite;


### PR DESCRIPTION
## Summary
- set a fixed background image for `marginary.html`
- make hero wrapper span the full width so the main text fits the page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68509ce3a9088322a05157a4d049cfb4