### PR TITLE
Fix marginary text wrapping

### DIFF
--- a/css/imaginary-solutions.webflow.css
+++ b/css/imaginary-solutions.webflow.css
@@ -2496,3 +2496,7 @@
     text-shadow: 0 0 6px rgba(0, 0, 0, 0.4);
   }
 }
+
+.no-wrap {
+  white-space: nowrap;
+}

--- a/marginary.html
+++ b/marginary.html
@@ -203,8 +203,8 @@
     </div>
     <div data-w-id="cc6747b0-5c46-8cd4-59d5-693d5595ef5b" style="opacity:0" class="container-3">
       <div class="hero-wrapper-two">
-        <p id="rotating-text" class="paragraph-2" style="font-size:72px;text-align:center;">Welcome!</p><br>
-	<p class="paragraph-2">Search <a href="SearchLedger/index.html" class="rl_navbar5_item-titlee-sealed black-shimmer">The Ledger</a>, if you are plighted.<br>Enter <a href="Nyetscape.html" class="rl_navbar5_item-titlee-sealed black-shimmer">Nyetology</a>, if you are blighted.<br><br>If you are seeking cement, feel free to contact us at<br><a href="mailto:cement@imaginary.solutions" class="black-shimmer">cement@imaginary.solutions</a></p>
+        <p id="rotating-text" class="paragraph-2 no-wrap" style="font-size:72px;text-align:center;">Welcome!</p><br>
+	<p class="paragraph-2">Search <a href="SearchLedger/index.html" class="rl_navbar5_item-titlee-sealed black-shimmer">The Ledger</a>, if you are plighted.<br>Enter <a href="Nyetscape.html" class="rl_navbar5_item-titlee-sealed black-shimmer">Nyetology</a>, if you are blighted.<br><br>If you are seeking cement, feel free to contact us at<br><a href="mailto:cement@imaginary.solutions" class="black-shimmer no-wrap">cement@imaginary.solutions</a></p>
       </div>
       <div class="div-block"></div>
     </div>


### PR DESCRIPTION
## Summary
- add `.no-wrap` CSS rule
- prevent rotating hero text from wrapping on small screens
- keep the cement email address on one line

## Testing
- `npm test` *(fails: Could not read package.json)*
- `make test` *(fails: No rule to make target `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6850b1ef47ec8322900a3c08563bc92c