### PR TITLE
Enable token-gated comments for SearchLedger entries

### DIFF
--- a/SearchLedger/index.html
+++ b/SearchLedger/index.html
@@ -76,8 +76,9 @@
         </footer>
     </div>
     <script src="ledger.js"></script>
+    <script src="tokens.js"></script>
 
-<script>
+    <script>
 let allLedgerEntries = [];
 
 
@@ -175,24 +176,87 @@ let allLedgerEntries = [];
 
 
 
+        function renderComments(ref) {
+            const commentList = document.getElementById('commentList');
+            if (!commentList) return;
+            commentList.innerHTML = '';
+            const comments = JSON.parse(localStorage.getItem(`comments-${ref}`) || '[]');
+            comments.forEach(text => {
+                const li = document.createElement('li');
+                li.textContent = text;
+                commentList.appendChild(li);
+            });
+        }
+
+        function showCommentSection(ref) {
+            const container = document.getElementById('ledgerEntries');
+            const commentDiv = document.createElement('div');
+            commentDiv.className = 'mt-4';
+            commentDiv.innerHTML = `
+                <h2 class="font-bold mb-2">Comments</h2>
+                <ul id="commentList" class="mb-4 list-disc pl-5"></ul>
+                <form id="commentForm" class="flex flex-col space-y-2">
+                    <textarea id="commentInput" class="border p-2" placeholder="Add a comment..."></textarea>
+                    <button type="submit" class="bg-black text-white px-4 py-2">Submit</button>
+                </form>
+            `;
+            container.appendChild(commentDiv);
+
+            const form = commentDiv.querySelector('#commentForm');
+            form.addEventListener('submit', (e) => {
+                e.preventDefault();
+                const input = commentDiv.querySelector('#commentInput');
+                const text = input.value.trim();
+                if (!text) return;
+                const comments = JSON.parse(localStorage.getItem(`comments-${ref}`) || '[]');
+                comments.push(text);
+                localStorage.setItem(`comments-${ref}`, JSON.stringify(comments));
+                input.value = '';
+                renderComments(ref);
+            });
+
+            renderComments(ref);
+        }
+
+        function handleRefToken() {
+            const params = new URLSearchParams(window.location.search);
+            const ref = params.get('ref');
+            const token = params.get('token');
+            if (!ref || !token) return false;
+
+            const entry = ledgerEntries.find(e => e.id === ref);
+            if (!entry) {
+                displayEntries([]);
+                return true;
+            }
+            displayEntries([entry]);
+            if (hasValidToken(ref, token)) {
+                showCommentSection(ref);
+            }
+            return true;
+        }
+
         document.addEventListener('DOMContentLoaded', () => {
             allLedgerEntries = ledgerEntries.slice();
-            displayEntries(allLedgerEntries);
 
-            const searchInput = document.getElementById('searchInput');
-            searchInput.addEventListener('input', (e) => {
-                const searchTerm = e.target.value.toLowerCase();
-                if (!searchTerm) {
-                    displayEntries(allLedgerEntries);
-                    return;
-                }
-                const filteredEntries = allLedgerEntries.filter(entry => {
-                    return (entry.id && entry.id.toLowerCase().includes(searchTerm)) ||
-                           (entry.title && entry.title.toLowerCase().includes(searchTerm)) ||
-                           (entry.description && entry.description.toLowerCase().includes(searchTerm));
+            if (!handleRefToken()) {
+                displayEntries(allLedgerEntries);
+
+                const searchInput = document.getElementById('searchInput');
+                searchInput.addEventListener('input', (e) => {
+                    const searchTerm = e.target.value.toLowerCase();
+                    if (!searchTerm) {
+                        displayEntries(allLedgerEntries);
+                        return;
+                    }
+                    const filteredEntries = allLedgerEntries.filter(entry => {
+                        return (entry.id && entry.id.toLowerCase().includes(searchTerm)) ||
+                               (entry.title && entry.title.toLowerCase().includes(searchTerm)) ||
+                               (entry.description && entry.description.toLowerCase().includes(searchTerm));
+                    });
+                    displayEntries(filteredEntries, searchTerm);
                 });
-                displayEntries(filteredEntries, searchTerm);
-            });
+            }
             setTimeout(updateLedgerVisuals, 100);
         });
 

--- a/SearchLedger/tokens.js
+++ b/SearchLedger/tokens.js
@@ -1,0 +1,7 @@
+const entryTokens = {
+  "-1": ["test"],
+};
+
+function hasValidToken(ref, token) {
+  return entryTokens[ref] && entryTokens[ref].includes(token);
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "LegendaryLad.github.io",
+  "version": "1.0.0",
+  "description": "Static site for imaginary.solutions",
+  "scripts": {
+    "test": "echo \"No tests defined\" && exit 0"
+  }
+}


### PR DESCRIPTION
## Summary
- allow URLs with `ref` and `token` parameters to load a single ledger entry
- validate tokens via new `tokens.js` file and enable a local comment section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a750ebc39483228594410a6766c69a