### PR TITLE
Fix tokens list syntax to prevent ledger failure

### DIFF
--- a/SearchLedger/tokens.js
+++ b/SearchLedger/tokens.js
@@ -28,7 +28,7 @@ const entryTokens = {
   "-357": ["armload"],
   "-358": ["bedrock"],
   "-359": ["chilled"],
-  "-360": ["dawning"],
+  "-360": ["dawning"]
 };
 
 function hasValidToken(ref, token) {


### PR DESCRIPTION
## Summary
- remove trailing comma from SearchLedger token map

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7f9b9bfc083229ff62e573bf53e75